### PR TITLE
Johnt/develop

### DIFF
--- a/PageSort.Core/Enums/AllEnums.cs
+++ b/PageSort.Core/Enums/AllEnums.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace PageSort.Core.Enums;
 
-internal enum OperatorType
+public enum OperatorType
 {
     Equals,
     NotEquals,

--- a/PageSort.Core/Extensions/DictionaryExtensions.cs
+++ b/PageSort.Core/Extensions/DictionaryExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -29,43 +30,7 @@ public static class DictionaryExtensions
             }
         }
     }
-    /// <summary>
-    /// Maps a collection of dictionaries to a strongly-typed IEnumerable of TDestination.
-    /// Only properties that match dictionary keys (case-insensitive) will be set.
-    /// </summary>
-    public static IEnumerable<TDestination> MapTo<TDestination>(this IEnumerable<Dictionary<string, object>> source) 
-        where TDestination : new()
-    {
-        if (source == null) yield break;
 
-        var properties = typeof(TDestination).GetProperties(BindingFlags.Public | BindingFlags.Instance)
-            .Where(p => p.CanWrite)
-            .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
-
-        foreach (var dict in source)
-        {
-            var obj = new TDestination();
-
-            foreach (var kvp in dict)
-            {
-                if (properties.TryGetValue(kvp.Key, out var prop))
-                {
-                    try
-                    {
-                        var targetType = Nullable.GetUnderlyingType(prop.PropertyType) ?? prop.PropertyType;
-                        var safeValue = kvp.Value == null ? null : Convert.ChangeType(kvp.Value, targetType);
-                        prop.SetValue(obj, safeValue);
-                    }
-                    catch
-                    {
-
-                    }
-                }
-            }
-
-            yield return obj;
-        }
-    }
 
     /// <summary>
     /// Converts a collection of dictionaries to a collection of dynamic objects (ExpandoObject),

--- a/PageSort.Core/Extensions/IQueryableExtension.cs
+++ b/PageSort.Core/Extensions/IQueryableExtension.cs
@@ -154,6 +154,58 @@ public static class IQueryableExtension
         return source.Select(selector);
     }
 
+    public static IQueryable<TDestination> ProjectToDestination<TSource, TDestination>(this IQueryable<TSource> source, string[] fields)
+    where TDestination : class, new()
+    {
+        var sourceProps = typeof(TSource).GetProperties()
+            .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+        var destProps = typeof(TDestination).GetProperties()
+            .Where(p => p.CanWrite && p.GetSetMethod() != null)
+            .ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
+
+        // Build: x => new TDestination { Prop1 = x.Prop1, ... }
+        var parameter = Expression.Parameter(typeof(TSource), "x");
+        var bindings = new List<MemberBinding>();
+
+        foreach (var field in fields)
+        {
+            if (sourceProps.TryGetValue(field, out var sourceProp) &&
+                destProps.TryGetValue(field, out var destProp))
+            {
+                var propertyAccess = Expression.Property(parameter, sourceProp);
+                Expression bindExpression = propertyAccess;
+
+                // Handle type conversion if needed
+                if (sourceProp.PropertyType != destProp.PropertyType)
+                {
+                    var sourceType = Nullable.GetUnderlyingType(sourceProp.PropertyType) ?? sourceProp.PropertyType;
+                    var destType = Nullable.GetUnderlyingType(destProp.PropertyType) ?? destProp.PropertyType;
+
+                    if (sourceType == destType || destType.IsAssignableFrom(sourceType))
+                    {
+                        bindExpression = Expression.Convert(propertyAccess, destProp.PropertyType);
+                    }
+                }
+
+                bindings.Add(Expression.Bind(destProp, bindExpression));
+            }
+        }
+
+        if (bindings.Count == 0)
+        {
+            throw new InvalidOperationException("No valid property mappings found");
+        }
+
+        var memberInit = Expression.MemberInit(
+            Expression.New(typeof(TDestination)),
+            bindings
+        );
+
+        var lambda = Expression.Lambda<Func<TSource, TDestination>>(memberInit, parameter);
+
+        return source.Select(lambda);
+    }
 
     /// <summary>
     /// Applies dynamic filters to an IQueryable based on a list of Filter objects.

--- a/PageSort.Core/PageQuery.cs
+++ b/PageSort.Core/PageQuery.cs
@@ -64,17 +64,9 @@ public sealed class Filter
     /// </summary>
     public object Value { get; } = null!;
 
-    private Filter(string field, string @operator, object value)
+    private Filter(string field, OperatorType @operator, object value)
     {
-
-        if (!Enum.TryParse<OperatorType>(@operator, out var op))
-        {
-            throw new ArgumentException($"Invalid operator type: {value}");
-        }
-
-        ValidateOperator(value, op);
-
-        Operator = op switch
+        Operator = @operator switch
         {
             OperatorType.Equals => "=",
             OperatorType.NotEquals => "!=",
@@ -85,13 +77,13 @@ public sealed class Filter
             OperatorType.Contains => "Contains",
             OperatorType.StartsWith => "StartsWith",
             OperatorType.EndsWith => "EndsWith",
-            _ => throw new ArgumentOutOfRangeException()
+            _ => throw new ArgumentOutOfRangeException(nameof(@operator), @operator, null)
         };
         Field = field;
         Value = value;
     }
 
-    public static Filter Create(string field, string @operator, object value)
+    public static Filter Create(string field, OperatorType @operator, object value)
     {
         return new Filter(field, @operator, value);
     }

--- a/PageSort.Core/PagingHelper.cs
+++ b/PageSort.Core/PagingHelper.cs
@@ -45,55 +45,6 @@ namespace PageSort.Core
             };
         }
 
-        /// <summary>
-        /// Dynamically selects specified fields from the collection and pages the result.
-        /// Returns a collection of key-value pairs representing field names and values.
-        /// </summary>
-        /// <typeparam name="TSource">The type of the source collection items.</typeparam>
-        /// <param name="collection">The source collection to page.</param>
-        /// <param name="pageQuery">The paging parameters including requested fields.</param>
-        /// <returns>A <see cref="PagedResult{KeyValuePair}"/> containing the paged dictionary items.</returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="collection"/> or <paramref name="pageQuery"/> is null.</exception>
-        /// <exception cref="InvalidOperationException">Thrown if no fields are provided or sort field is missing in selection.</exception>
-        public static PagedResult<KeyValuePair<string, object?>> GeneratePaging<TSource>(IQueryable<TSource> collection, AdvancedPageQuery pageQuery)
-        {
-            ArgumentNullException.ThrowIfNull(collection);
-            ArgumentNullException.ThrowIfNull(pageQuery);
-
-            if (pageQuery.Fields is null or [])
-                throw new InvalidOperationException("Fields must be provided for dynamic paging.");
-
-            var fields = pageQuery.Fields.Select(f => f.Trim()).ToArray();
-
-            if (pageQuery.Filters?.Count > 0)
-            {
-                collection = collection.ApplyFilters(pageQuery.Filters);
-            }
-
-            if (!string.IsNullOrEmpty(pageQuery.SortProperty) && !fields.Contains(pageQuery.SortProperty, StringComparer.OrdinalIgnoreCase))
-                throw new InvalidOperationException($"Sort field '{pageQuery.SortProperty}' must be part of the selected fields.");
-
-            if (pageQuery.SortProperty is not null)
-                collection = collection.OrderByProperty(pageQuery.SortProperty, pageQuery.SortDirection ?? ListSortDirection.Ascending);
-
-            var projectedQuery = collection.SelectDynamic(fields);
-
-            int totalCount = projectedQuery.Count();
-            int totalPages = (int)Math.Ceiling(totalCount / (double)pageQuery.PageSize);
-
-            var items = projectedQuery.Page(pageQuery.PageNumber, pageQuery.PageSize);
-
-            return new PagedResult<KeyValuePair<string, object?>>
-            {
-                CurrentPage = pageQuery.PageNumber,
-                PageSize = pageQuery.PageSize,
-                TotalCount = totalCount,
-                TotalPages = totalPages,
-                PreviousPage = pageQuery.PageNumber > 1,
-                NextPage = pageQuery.PageNumber < totalPages,
-                Collection = items.ToEnumerable()
-            };
-        }
 
         /// <summary>
         /// Dynamically selects specified fields from the source collection, maps them to <typeparamref name="TDestination"/>, and pages the result.
@@ -133,12 +84,12 @@ namespace PageSort.Core
             if (pageQuery.SortProperty is not null)
                 collection = collection.OrderByProperty(pageQuery.SortProperty, pageQuery.SortDirection ?? ListSortDirection.Ascending);
 
-            var projectedQuery = collection.SelectDynamic(fields);
-
-            int totalCount = projectedQuery.Count();
+            int totalCount = collection.Count();
             int totalPages = (int)Math.Ceiling(totalCount / (double)pageQuery.PageSize);
 
-            var items = projectedQuery.Page(pageQuery.PageNumber, pageQuery.PageSize);
+            IQueryable<TDestination> projected = collection.ProjectToDestination<TSource, TDestination>(fields);
+
+            IQueryable<TDestination> pagedCollection = projected.Page(pageQuery.PageNumber, pageQuery.PageSize);
 
             return new PagedResult<TDestination>
             {
@@ -148,7 +99,7 @@ namespace PageSort.Core
                 TotalPages = totalPages,
                 PreviousPage = pageQuery.PageNumber > 1,
                 NextPage = pageQuery.PageNumber < totalPages,
-                Collection = items.MapTo<TDestination>()
+                Collection = pagedCollection
             };
         }
 
@@ -160,12 +111,6 @@ namespace PageSort.Core
         /// Async version of <see cref="GeneratePaging(IQueryable{T}, PageQuery)"/>.
         /// </summary>
         public static Task<PagedResult<T>> GeneratePagingAsync(IQueryable<T> collection, PageQuery pageQuery)
-            => Task.FromResult(GeneratePaging(collection, pageQuery));
-
-        /// <summary>
-        /// Async version of <see cref="GeneratePagingDynamic{TSource}(IQueryable{TSource}, PageQuery)"/>.
-        /// </summary>
-        public static Task<PagedResult<KeyValuePair<string, object?>>> GeneratePagingAsync<TSource>(IQueryable<TSource> collection, AdvancedPageQuery pageQuery)
             => Task.FromResult(GeneratePaging(collection, pageQuery));
 
         /// <summary>

--- a/PageSort.Core/PagingHelper.cs
+++ b/PageSort.Core/PagingHelper.cs
@@ -81,7 +81,8 @@ namespace PageSort.Core
             if (!string.IsNullOrEmpty(pageQuery.SortProperty) && !fields.Contains(pageQuery.SortProperty, StringComparer.OrdinalIgnoreCase))
                 throw new InvalidOperationException($"Sort field '{pageQuery.SortProperty}' must be part of the selected fields.");
 
-            if (pageQuery.SortProperty is not null)
+            var tSourceFields = typeof(TSource).GetProperties();
+            if (pageQuery.SortProperty is not null && tSourceFields.Any(f => f.Name.Equals(pageQuery.SortProperty, StringComparison.OrdinalIgnoreCase)))
                 collection = collection.OrderByProperty(pageQuery.SortProperty, pageQuery.SortDirection ?? ListSortDirection.Ascending);
 
             int totalCount = collection.Count();

--- a/PageSort.Core/PagingHelper.cs
+++ b/PageSort.Core/PagingHelper.cs
@@ -1,6 +1,7 @@
 ﻿using PageSort.Core.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -63,12 +64,17 @@ namespace PageSort.Core
             ArgumentNullException.ThrowIfNull(pageQuery);
 
             if (pageQuery.Fields is null or [])
-                throw new InvalidOperationException("Fields must be provided for dynamic paging.");
+            {
+                pageQuery.Fields = [.. typeof(TSource).GetProperties().Select(p => p.Name)];
+            }
 
-            var fields = pageQuery.Fields.Select(f => f.Trim()).ToArray();
+            var fields = pageQuery.Fields
+                .Select(f => f.Trim())
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
             var destinationProperties = typeof(TDestination).GetProperties()
                 .Select(p => p.Name)
-                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
             if (!destinationProperties.Any(p => fields.Contains(p, StringComparer.OrdinalIgnoreCase)))
                 throw new InvalidOperationException("At least one destination property must be part of the selected fields.");
@@ -81,14 +87,10 @@ namespace PageSort.Core
             if (!string.IsNullOrEmpty(pageQuery.SortProperty) && !fields.Contains(pageQuery.SortProperty, StringComparer.OrdinalIgnoreCase))
                 throw new InvalidOperationException($"Sort field '{pageQuery.SortProperty}' must be part of the selected fields.");
 
-            var tSourceFields = typeof(TSource).GetProperties();
-            if (pageQuery.SortProperty is not null && tSourceFields.Any(f => f.Name.Equals(pageQuery.SortProperty, StringComparison.OrdinalIgnoreCase)))
-                collection = collection.OrderByProperty(pageQuery.SortProperty, pageQuery.SortDirection ?? ListSortDirection.Ascending);
-
             int totalCount = collection.Count();
             int totalPages = (int)Math.Ceiling(totalCount / (double)pageQuery.PageSize);
 
-            IQueryable<TDestination> projected = collection.ProjectToDestination<TSource, TDestination>(fields);
+            IQueryable<TDestination> projected = collection.ProjectToDestination<TSource, TDestination>([.. fields]);
 
             IQueryable<TDestination> pagedCollection = projected.Page(pageQuery.PageNumber, pageQuery.PageSize);
 

--- a/PageSort.Tests/PageQueryTests.cs
+++ b/PageSort.Tests/PageQueryTests.cs
@@ -1,5 +1,6 @@
 using PageSort.Core;
 using PageSort.Core.Attributes;
+using PageSort.Core.Enums;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,6 +17,23 @@ namespace PageSort.Tests
 
         [MarkAsSensitive]
         public string Password { get; set; }
+
+        public string Age90Daysago
+        {
+            get
+            {
+                return $"{Age - 90}";
+            }
+        }
+    }
+
+    public class UserDTO
+    {
+        public int Age { get; set; }
+        public string Name { get; set; }
+
+        public string Age90Daysago { get; set; } = string.Empty;
+
     }
 
     public class FilteredUser
@@ -113,7 +131,7 @@ namespace PageSort.Tests
                 PageSize = 10,
                 Filters =
                 [
-                    Filter.Create(field: "Age",  @operator: "GreaterThan", value: "2")
+                    Filter.Create(field: "Age",  @operator: OperatorType.GreaterThan, value: "2")
                 ],
                 Fields = ["Name", "Age"],
                 SortProperty = "Age",
@@ -140,14 +158,14 @@ namespace PageSort.Tests
                     PageSize = 10,
                     Filters =
                     [
-                        Filter.Create(field: "Age",  @operator: "Contains", value: "20")
+                        Filter.Create(field: "Age",  @operator: OperatorType.Contains, value: "20")
                     ],
                     Fields = ["Name", "Age"],
                     SortProperty = "Age",
                     SortDirection = System.ComponentModel.ListSortDirection.Ascending
                 };
             });
-            
+
         }
 
         [Fact]
@@ -199,6 +217,29 @@ namespace PageSort.Tests
             {
                 var pagedResult = PageSort.Core.Page<User>.GeneratePaging(users.AsQueryable(), pageQuery);
             });
+        }
+
+
+        [Fact]
+        public void Test_GeneratePagingDynamic_Correct_Field()
+        {
+            var pageQuery = new PageSort.Core.AdvancedPageQuery
+            {
+                PageNumber = 1,
+                PageSize = 10,
+                Filters =
+                [
+                    Filter.Create(field: "Age",  @operator: OperatorType.LessThan, value: "10")
+                ],
+                Fields = ["Name", "Age"],
+                SortProperty = "Age",
+                SortDirection = System.ComponentModel.ListSortDirection.Ascending
+            };
+
+            var pagedResult = PageSort.Core.Page<User>.GeneratePaging<User, UserDTO>(users.AsQueryable(), pageQuery);
+
+            Assert.Equal(1, pagedResult.CurrentPage);
+
         }
     }
 }

--- a/PageSort.Tests/PageQueryTests.cs
+++ b/PageSort.Tests/PageQueryTests.cs
@@ -24,11 +24,11 @@ namespace PageSort.Tests
         public string Name { get; set; }
     }
 
-    public class UnitTest1
+    public class PageQueryTests
     {
         readonly List<User> users = new();
 
-        public UnitTest1()
+        public PageQueryTests()
         {
             for (int i = 0; i < 100; i++)
             {


### PR DESCRIPTION
This pull request introduces significant improvements to the paging and projection utilities in the codebase, focusing on type safety, flexibility, and maintainability. The changes include replacing string-based operators with a strongly-typed enum, removing a fragile dictionary-to-object mapping method, and introducing a robust, expression-based projection mechanism for mapping query results to DTOs. Additionally, the paging helpers and tests have been updated to reflect these improvements.

**Paging and Projection Enhancements:**

* Introduced a new `ProjectToDestination` extension method in `IQueryableExtension.cs` that uses expression trees to project queryable results from a source type to a destination type based on a list of fields, ensuring type safety and supporting property type conversion.
* Updated the `GeneratePaging<TSource, TDestination>` method in `PagingHelper.cs` to use `ProjectToDestination` for mapping, defaulting to all source properties if no fields are specified, and leveraging immutable collections for field/property handling. [[1]](diffhunk://#diff-f52febdc9661e9038a8954d1d2188e5186bad02c7247c1bf166b64d794f3c01bL115-R77) [[2]](diffhunk://#diff-f52febdc9661e9038a8954d1d2188e5186bad02c7247c1bf166b64d794f3c01bL133-R95) [[3]](diffhunk://#diff-f52febdc9661e9038a8954d1d2188e5186bad02c7247c1bf166b64d794f3c01bL151-R105)

**Operator Handling Improvements:**

* Changed `OperatorType` from internal to public and refactored the `Filter` class to use the strongly-typed `OperatorType` instead of string operators, improving type safety and clarity in filter creation. [[1]](diffhunk://#diff-aa45091c1792dc488ec9deee43a88b16fd10e54db13fc84992dbf27fb8d34affL9-R9) [[2]](diffhunk://#diff-3ab5b406934c98414f3fa3c5607d34e04ebbeb9c8ae9765d9856f4b736b5aacbL67-R69) [[3]](diffhunk://#diff-3ab5b406934c98414f3fa3c5607d34e04ebbeb9c8ae9765d9856f4b736b5aacbL88-R86)

**Codebase Simplification and Cleanup:**

* Removed the fragile `MapTo<TDestination>` method from `DictionaryExtensions.cs`, as projection is now handled by the new expression-based approach.
* Cleaned up unused or redundant usings and methods across several files to streamline the codebase. [[1]](diffhunk://#diff-27076a378baf80a47c5674e8a5c3dc3c2c75715e1d053b4bbf741d16555c31fcR5) [[2]](diffhunk://#diff-f52febdc9661e9038a8954d1d2188e5186bad02c7247c1bf166b64d794f3c01bR4) [[3]](diffhunk://#diff-f52febdc9661e9038a8954d1d2188e5186bad02c7247c1bf166b64d794f3c01bL165-L170) [[4]](diffhunk://#diff-f52febdc9661e9038a8954d1d2188e5186bad02c7247c1bf166b64d794f3c01bL48-L96)

**Test Improvements:**

* Renamed the main test file and class to `PageQueryTests` for clarity, added DTOs and new test cases to verify the new projection and filter logic, and updated existing tests to use the strongly-typed `OperatorType`. [[1]](diffhunk://#diff-dadf309a6123698f60d1b9fd9b2643869ded882a1ec6876c60dde8f5d3f61448R3) [[2]](diffhunk://#diff-dadf309a6123698f60d1b9fd9b2643869ded882a1ec6876c60dde8f5d3f61448R20-R36) [[3]](diffhunk://#diff-dadf309a6123698f60d1b9fd9b2643869ded882a1ec6876c60dde8f5d3f61448L27-R49) [[4]](diffhunk://#diff-dadf309a6123698f60d1b9fd9b2643869ded882a1ec6876c60dde8f5d3f61448L116-R134) [[5]](diffhunk://#diff-dadf309a6123698f60d1b9fd9b2643869ded882a1ec6876c60dde8f5d3f61448L143-R161) [[6]](diffhunk://#diff-dadf309a6123698f60d1b9fd9b2643869ded882a1ec6876c60dde8f5d3f61448R221-R243)